### PR TITLE
Fix #126 assay rows dropped in coercion from LongTable -> data.table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CoreGx
 Type: Package
 Title: Classes and Functions to Serve as the Basis for Other 'Gx' Packages
-Version: 1.5.5
+Version: 1.5.6
 Date: 2021-10-04
 Authors@R: c(
     person("Petr","Smirnov", email = "petr.smirnov@uhnresearch.ca", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CoreGx News File
 
+## v1.5.6
+- Fix bug in LongTable -> data.table coerce method that was causing rows of some assays to be dropped
+
 ## v1.5.5
 - Fix bug in .distancePointLine where function fails with no intercept specified (Issue #120)
 - Added support for aggregating an assay inside of a LongTable class object

--- a/R/methods-coerce.R
+++ b/R/methods-coerce.R
@@ -28,9 +28,10 @@ setAs('LongTable', 'data.table', def=function(from) {
     # join assays into a single table
     DT <- longTableData[[1]]
     longTableData[[1]] <- NULL
-    for (i in seq_along(longTableData))
-        DT <- merge.data.table(DT, longTableData[[i]],
-            suffixes=c('', paste0('._', i)), by=.EACHI)
+    for (i in seq_along(longTableData)) {
+        DT <- merge.data.table(DT, longTableData[[i]], 
+            suffixes=c('', paste0('._', i)), by=.EACHI, all.x=TRUE, all.y=TRUE)
+    }
 
     # extract assay columns
     assayCols <- assayCols(from)


### PR DESCRIPTION
* The resolution was to add all.x and all.y equal to TRUE in the merge.data.table call