### PR TITLE
Fixing a bug in sorting the y values in the same order as x

### DIFF
--- a/.github/workflows/R-CMD-check-devel.yaml
+++ b/.github/workflows/R-CMD-check-devel.yaml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: '4', bioc: '3.14', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
+          - { os: ubuntu-latest, r: '4.2', bioc: '3.15', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
           
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -112,7 +112,7 @@
             stop("x must contain only real numbers, NA-values, and/or -Inf (if x_as_log flag is set to TRUE).")
         }
 
-        if (x_as_log == FALSE && min(x) < 0) {
+        if (x_as_log == FALSE && min(x, na.rm=TRUE) < 0) {
             if (verbose == 2) {
                 message("x:")
                 message(x)
@@ -208,7 +208,7 @@
         
         if (missing(pars)) {
             
-            if (y_as_log == FALSE && min(y) < 0) {
+            if (y_as_log == FALSE && min(y, na.rm=TRUE) < 0) {
                 if (verbose) {
                   warning("Negative y-values encountered. y data may be inappropriate, or 'y_as_log' flag may be set incorrectly.")
                   if (verbose == 2) {
@@ -220,7 +220,7 @@
                 }
             }
             
-            if (y_as_pct == TRUE && max(y) < 5) {
+            if (y_as_pct == TRUE && max(y, na.rm=TRUE) < 5) {
                 if (verbose) {
                   warning("Warning: 'y_as_pct' flag may be set incorrectly.")
                   if (verbose == 2) {
@@ -232,7 +232,7 @@
                 }
             }
             
-            if (y_as_pct == FALSE && max(y) > 5) {
+            if (y_as_pct == FALSE && max(y, na.rm=TRUE) > 5) {
                 if (verbose) {
                   warning("Warning: 'y_as_pct' flag may be set incorrectly.")
                   if (verbose == 2) {
@@ -352,6 +352,11 @@
     }
     
     if (!missing(y)) {
+        
+        if (InputUnsorted) {
+            y <- y[xOrder]
+        }
+        
         if (any(is.na(x) & (!is.na(y)))) {
             warning("Missing x-values with non-missing y-values encountered. Removed y-values correspoding to those x-values.")
             myx <- !is.na(x)
@@ -366,10 +371,10 @@
             y <- as.numeric(y[myy])
         }
         
-        if (InputUnsorted) {
-            y <- y[xOrder]
-        }
-        
+        myxy <- complete.cases(x,y)
+        x <- x[myxy]
+        y <- y[myxy]
+                     
         if (trunc) {
             y = pmin(as.numeric(y), ifelse(y_to_frac,100,1))
             y = pmax(as.numeric(y), 0)
@@ -399,7 +404,7 @@
             y <- y/100
         }
         
-        if (length(unique(x)) < 3) {
+         if (length(unique(x)) < 3) {
             stop("Less than 3 unique dose points left after cleaning data, please pass in enough valid measurements.")
             
         }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -341,8 +341,9 @@
     if (x_to_log) {
         x <- log10(x)
     }
-    ### Shouldnt we sort y in same order?????
+    ### Note, if Y is passed in, it is sorted in this same order below. This is not obvious from the code right away. 
     if (is.unsorted(x)) {
+        InputUnsorted <- TRUE
         warning("x-values passed in unsorted. Sorting x-values and corresponding y-values (if passed in).")
         xOrder <- order(x)
         x <- x[xOrder]
@@ -363,7 +364,7 @@
             y <- as.numeric(y[myy])
         }
         
-        if (is.unsorted(x)) {
+        if (InputUnsorted) {
             y <- y[xOrder]
         }
         

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -347,6 +347,8 @@
         warning("x-values passed in unsorted. Sorting x-values and corresponding y-values (if passed in).")
         xOrder <- order(x)
         x <- x[xOrder]
+    } else {
+        InputUnsorted <- FALSE 
     }
     
     if (!missing(y)) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -369,7 +369,7 @@
         }
         
         if (trunc) {
-            y = pmin(as.numeric(y), 1)
+            y = pmin(as.numeric(y), ifelse(y_to_frac,100,1))
             y = pmax(as.numeric(y), 0)
         }
         


### PR DESCRIPTION
Previous code tried to be clever, but failed to keep track of the fact that if we sort x, is.unsorted(x) will start to evaluate to false later. 

IMO, the flow is better working with 1 variable at a time, so I added a flag to remember the sorted status of the data.