### PR TITLE
Missing rescaling in the .residual function

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -949,7 +949,7 @@
         if (trunc == FALSE) {
             
             if (n == 1) {
-                return(sum(diffs^2))
+                return(sum(diffs^2/scale^2))
             }
             
             return(sum(-log(.dmednnormals(diffs, n, scale))))


### PR DESCRIPTION
the scale parameter should be used to set the sd of the normal used in evaluating the logprob