### PR TITLE
fix .checkForIdColumn

### DIFF
--- a/R/CoreSet-class.R
+++ b/R/CoreSet-class.R
@@ -281,6 +281,8 @@ CoreSet <- function(name, molecularProfiles=list(), sample=data.frame(),
         }
         return(df)
     }
+    return(df)
+    
 }
 
 #' @noRd


### PR DESCRIPTION
Hi guys, 

the treatment checking was failing if the treatment data.frame contained the new 'treatmentid' column, because the checker was not returning the treatment df. 
